### PR TITLE
Fixes use of missing method boundary

### DIFF
--- a/python/lsst/skymap/healpixSkyMap.py
+++ b/python/lsst/skymap/healpixSkyMap.py
@@ -59,7 +59,7 @@ class HealpixTractInfo(TractInfo):
     """Tract for the HealpixSkyMap"""
     def __init__(self, nSide, ident, nest, patchInnerDimensions, patchBorder, ctrCoord, tractOverlap, wcs):
         """Set vertices from nside, ident, nest"""
-        theta, phi = healpy.vec2ang(numpy.transpose(healpy.boundary(nSide, ident, nest=nest)))
+        theta, phi = healpy.vec2ang(numpy.transpose(healpy.boundaries(nSide, ident, nest=nest)))
         vertexList = [angToCoord(thetaphi) for thetaphi in zip(theta,phi)]
         super(HealpixTractInfo, self).__init__(ident, patchInnerDimensions, patchBorder, ctrCoord,
                                                vertexList, tractOverlap, wcs)


### PR DESCRIPTION
The code used healpy.boundary, but this method
does not exist in healpy 1.7.4 (the version distributed)
with v9_2.  Changing the name to boundaries causes
the unit tests to pass.
