### PR TITLE
RingsSkyMap: catch exceptions from wcs

### DIFF
--- a/python/lsst/skymap/ringsSkyMap.py
+++ b/python/lsst/skymap/ringsSkyMap.py
@@ -23,7 +23,6 @@ from builtins import range
 
 import math
 
-import lsst.pex.exceptions as pexExceptions
 from lsst.pex.config import Field
 from lsst.afw.coord import IcrsCoord
 import lsst.afw.geom as afwGeom
@@ -169,17 +168,6 @@ class RingsSkyMap(CachingSkyMap):
         ringNum = int((dec - firstRingStart)/self._ringSize)
 
         tractList = list()
-
-        def coordInTract(tract):
-            """Is the 'icrsCoord' in the tract?"""
-            try:
-                pixels = tract.getWcs().skyToPixel(icrsCoord)
-            except (pexExceptions.DomainError, pexExceptions.RuntimeError):
-                # Point must be way off the tract
-                return False
-            return tract.getBBox().contains(afwGeom.Point2I(pixels))
-
-
         # ringNum denotes the closest ring to the specified coord
         # I will check adjacent rings which may include the specified coord
         for r in [ringNum - 1, ringNum, ringNum + 1]:
@@ -200,14 +188,14 @@ class RingsSkyMap(CachingSkyMap):
                     index += self._ringNums[i]
 
                 tract = self[index]
-                if coordInTract(tract):
+                if tract.contains(icrsCoord):
                     tractList.append(tract)
 
         # Always check tracts at poles
         # Southern cap is 0, Northern cap is the last entry in self
         for entry in [0, len(self)-1]:
             tract = self[entry]
-            if coordInTract(tract):
+            if tract.contains(icrsCoord):
                 tractList.append(tract)
 
         return tractList

--- a/python/lsst/skymap/ringsSkyMap.py
+++ b/python/lsst/skymap/ringsSkyMap.py
@@ -23,6 +23,7 @@ from builtins import range
 
 import math
 
+import lsst.pex.exceptions as pexExceptions
 from lsst.pex.config import Field
 from lsst.afw.coord import IcrsCoord
 import lsst.afw.geom as afwGeom
@@ -168,6 +169,17 @@ class RingsSkyMap(CachingSkyMap):
         ringNum = int((dec - firstRingStart)/self._ringSize)
 
         tractList = list()
+
+        def coordInTract(tract):
+            """Is the 'icrsCoord' in the tract?"""
+            try:
+                pixels = tract.getWcs().skyToPixel(icrsCoord)
+            except (pexExceptions.DomainError, pexExceptions.RuntimeError):
+                # Point must be way off the tract
+                return False
+            return tract.getBBox().contains(afwGeom.Point2I(pixels))
+
+
         # ringNum denotes the closest ring to the specified coord
         # I will check adjacent rings which may include the specified coord
         for r in [ringNum - 1, ringNum, ringNum + 1]:
@@ -188,14 +200,14 @@ class RingsSkyMap(CachingSkyMap):
                     index += self._ringNums[i]
 
                 tract = self[index]
-                if tract.getBBox().contains(afwGeom.Point2I(tract.getWcs().skyToPixel(coord.toIcrs()))):
+                if coordInTract(tract):
                     tractList.append(tract)
 
         # Always check tracts at poles
         # Southern cap is 0, Northern cap is the last entry in self
         for entry in [0, len(self)-1]:
             tract = self[entry]
-            if tract.getBBox().contains(afwGeom.Point2I(tract.getWcs().skyToPixel(coord.toIcrs()))):
+            if coordInTract(tract):
                 tractList.append(tract)
 
         return tractList

--- a/python/lsst/skymap/tractInfo.py
+++ b/python/lsst/skymap/tractInfo.py
@@ -189,7 +189,7 @@ class TractInfo(object):
         for coord in coordList:
             try:
                 pixelPos = self.getWcs().skyToPixel(coord.toIcrs())
-            except lsst.pex.exceptions.Exception:
+            except (lsst.pex.exceptions.DomainError, lsst.pex.exceptions.RuntimeError):
                 # the point is so far off the tract that its pixel position cannot be computed
                 continue
             box2D.include(pixelPos)

--- a/python/lsst/skymap/tractInfo.py
+++ b/python/lsst/skymap/tractInfo.py
@@ -162,8 +162,9 @@ class TractInfo(object):
 
         @note This routine will be more efficient if coord is ICRS.
         """
+        icrsCoord = coord.toIcrs()
         try:
-            pixel = self.getWcs().skyToPixel(coord.toIcrs())
+            pixel = self.getWcs().skyToPixel(icrsCoord)
         except (lsst.pex.exceptions.DomainError, lsst.pex.exceptions.RuntimeError):
             # Point must be way off the tract
             raise LookupError("Unable to determine pixel position for coordinate %s" % (coord,))
@@ -187,8 +188,9 @@ class TractInfo(object):
         """
         box2D = afwGeom.Box2D()
         for coord in coordList:
+            icrsCoord = coord.toIcrs()
             try:
-                pixelPos = self.getWcs().skyToPixel(coord.toIcrs())
+                pixelPos = self.getWcs().skyToPixel(icrsCoord)
             except (lsst.pex.exceptions.DomainError, lsst.pex.exceptions.RuntimeError):
                 # the point is so far off the tract that its pixel position cannot be computed
                 continue
@@ -311,8 +313,9 @@ class TractInfo(object):
 
     def contains(self, coord):
         """Does this tract contain the coordinate?"""
+        icrsCoord = coord.toIcrs()
         try:
-            pixels = self.getWcs().skyToPixel(coord.toIcrs())
+            pixels = self.getWcs().skyToPixel(icrsCoord)
         except (lsst.pex.exceptions.DomainError, lsst.pex.exceptions.RuntimeError):
             # Point must be way off the tract
             return False

--- a/python/lsst/skymap/tractInfo.py
+++ b/python/lsst/skymap/tractInfo.py
@@ -303,6 +303,15 @@ class TractInfo(object):
     def __getitem__(self, index):
         return self.getPatchInfo(index)
 
+    def contains(self, coord):
+        """Does this tract contain the coordinate?"""
+        try:
+            pixels = self.getWcs().skyToPixel(coord.toIcrs())
+        except (lsst.pex.exceptions.DomainError, lsst.pex.exceptions.RuntimeError):
+            # Point must be way off the tract
+            return False
+        return self.getBBox().contains(afwGeom.Point2I(pixels))
+
 
 class ExplicitTractInfo(TractInfo):
     """Information for a tract specified explicitly

--- a/tests/helper/skyMapTestCase.py
+++ b/tests/helper/skyMapTestCase.py
@@ -25,6 +25,7 @@ from builtins import zip
 import pickle
 
 import lsst.afw.geom as afwGeom
+import lsst.afw.coord as afwCoord
 import lsst.utils.tests
 
 from lsst.skymap import skyMapRegistry
@@ -252,6 +253,16 @@ class SkyMapTestCase(lsst.utils.tests.TestCase):
                     coordList=[tractInfo.getVertexList()[2]],
                     knownTractId=tractId,
                 )
+
+    def testTractContains(self):
+        """Test that TractInfo.contains works"""
+        skyMap = self.getSkyMap()
+        for tract in skyMap:
+            coord = tract.getCtrCoord()
+            self.assertTrue(tract.contains(coord))
+            opposite = afwCoord.IcrsCoord(coord.getLongitude() + 12*afwGeom.hours, -1*coord.getLatitude())
+            self.assertFalse(tract.contains(opposite))
+
 
     def assertTractPatchListOk(self, skyMap, coordList, knownTractId):
         """Assert that findTractPatchList produces the correct results

--- a/tests/testRingsSkyMap.py
+++ b/tests/testRingsSkyMap.py
@@ -2,18 +2,20 @@
 import unittest
 
 import lsst.utils.tests
+import lsst.afw.coord
+import lsst.afw.geom
 
 from lsst.skymap.ringsSkyMap import RingsSkyMap
 from helper import skyMapTestCase
 
 
-config = RingsSkyMap.ConfigClass()
-config.numRings = 3
 
 
 class RingsTestCase(skyMapTestCase.SkyMapTestCase):
 
     def setUp(self):
+        config = RingsSkyMap.ConfigClass()
+        config.numRings = 3
         self._NumTracts = 26  # Number of tracts to expect
         self._NeighborAngularSeparation = None  # Expected tract separation
         self._SkyMapClass = RingsSkyMap  # Class of SkyMap to test
@@ -23,6 +25,36 @@ class RingsTestCase(skyMapTestCase.SkyMapTestCase):
 
     def testTractSeparation(self):
         self.skipTest("A particular tract separation is not important for RingsSkyMap")
+
+
+class HscRingsTestCase(lsst.utils.tests.TestCase):
+    def setUp(self):
+        # This matches the HSC SSP configuration, on which the problem was discovered
+        config = RingsSkyMap.ConfigClass()
+        config.numRings = 120
+        config.projection = "TAN"
+        config.tractOverlap = 1.0/60  # Overlap between tracts (degrees)
+        config.pixelScale = 0.168
+        self.skymap = RingsSkyMap(config)
+
+    def tearDown(self):
+        del self.skymap
+
+    def testDm7770(self):
+        """Test that DM-7770 has been fixed
+
+        These operations previously caused:
+            lsst::pex::exceptions::RuntimeError: 'Error: wcslib
+            returned a status code of 9 at sky 30.18, -3.8 deg:
+            One or more of the world coordinates were invalid'
+
+        We are only testing function, and not the actual results.
+        """
+        coordList = [lsst.afw.coord.IcrsCoord(ra*lsst.afw.geom.degrees, dec*lsst.afw.geom.degrees) for
+                     ra, dec in [(30.18, -3.8), (31.3, -3.8), (31.3, -2.7), (30.18, -2.7)]]
+        for coord in coordList:
+            self.skymap.findAllTracts(coord)
+        self.skymap.findTractPatchList(coordList)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
wcs.skyToPixel can throw an exception if the coordinate is very
far off the image. That just means it isn't the image we're looking
for.

Thanks to Johnny Greco for reporting this bug.