### PR TITLE
DM-10686: RingsSkyMap: fix findAllTracts for poles

### DIFF
--- a/python/lsst/skymap/ringsSkyMap.py
+++ b/python/lsst/skymap/ringsSkyMap.py
@@ -158,13 +158,6 @@ class RingsSkyMap(CachingSkyMap):
 
         firstRingStart = self._ringSize*0.5 - 0.5*math.pi
 
-        if dec < firstRingStart:
-            # Southern cap
-            return self[0]
-        elif dec > firstRingStart*-1:
-            # Northern cap
-            return self[-1]
-
         ringNum = int((dec - firstRingStart)/self._ringSize)
 
         tractList = list()

--- a/tests/testRingsSkyMap.py
+++ b/tests/testRingsSkyMap.py
@@ -26,6 +26,18 @@ class RingsTestCase(skyMapTestCase.SkyMapTestCase):
     def testTractSeparation(self):
         self.skipTest("A particular tract separation is not important for RingsSkyMap")
 
+    def testPoles(self):
+        """Test that findAllTracts behaves at the poles
+
+        Testing fix to DM-10686.
+        """
+        skymap = self.getSkyMap()
+        deg = lsst.afw.geom.degrees
+        for ra in (0, 123, 321, 359.9):
+            tracts = skymap.findAllTracts(lsst.afw.coord.IcrsCoord(ra*deg, 90*deg))
+            self.assertListEqual(tracts, [skymap[len(skymap) - 1]])
+            tracts = skymap.findAllTracts(lsst.afw.coord.IcrsCoord(ra*deg, -90*deg))
+            self.assertListEqual(tracts, [skymap[0]])
 
 class HscRingsTestCase(lsst.utils.tests.TestCase):
     def setUp(self):


### PR DESCRIPTION
The initial pole check was wrong (doesn't allow other tracts to be
included) and unnecessary because the poles get picked up by the
check at the end.

Added a test.

Thought about allowing negative indexing into SkyMap, but decided
that would be a mistake because the SkyMap isn't really like a list,
but more like a dict.