### PR TITLE
DM-12529: Enum comparison should use == not is

### DIFF
--- a/examples/showVisitSkyMap.py
+++ b/examples/showVisitSkyMap.py
@@ -66,7 +66,7 @@ def main(rootDir, tract, visits, ccds=None, ccdKey='ccd', showPatch=False, saveF
             bbox = ccd.getBBox()
             ccdId = int(ccd.getSerial())
 
-            if (ccds is None or ccdId in ccds) and ccd.getType() is cameraGeom.SCIENCE:
+            if (ccds is None or ccdId in ccds) and ccd.getType() == cameraGeom.SCIENCE:
                 dataId = {'visit': visit, ccdKey: ccdId}
                 try:
                     md = butler.get("calexp_md", dataId)


### PR DESCRIPTION
The ccd.getType() is cameraGeom.SCIENCE condition no longer evaluates
to True where appropriate.  The condition here should be ==, not is.
It is likely the behavior changed along with the pybind11 wrapping.