### PR TITLE
DM-29944: Add HSC narrow band filters to dimension packer.

### DIFF
--- a/python/lsst/skymap/packers.py
+++ b/python/lsst/skymap/packers.py
@@ -37,7 +37,11 @@ class SkyMapDimensionPacker(DimensionPacker):
         skymap, tract, and patch, and may include band.
     """
 
-    SUPPORTED_FILTERS = [None] + list("ugrizyUBGVRIZYJHK")  # split string into single chars
+    SUPPORTED_FILTERS = (
+        [None]
+        + list("ugrizyUBGVRIZYJHK")  # split string into single chars
+        + [f"N{d}" for d in (387, 515, 656, 816, 1010)]  # HSC narrow-bands
+    )
     """band names supported by this packer.
 
     New filters should be added to the end of the list to maximize


### PR DESCRIPTION
It's unfortunate that this list is hard-coded at all, but there isn't an easy way out of that; we can't have an encoding that can handle all bands without actually enumerating them.