### PR TITLE
DM-30365: Add N921 to narrow band filters.

### DIFF
--- a/python/lsst/skymap/packers.py
+++ b/python/lsst/skymap/packers.py
@@ -40,7 +40,7 @@ class SkyMapDimensionPacker(DimensionPacker):
     SUPPORTED_FILTERS = (
         [None]
         + list("ugrizyUBGVRIZYJHK")  # split string into single chars
-        + [f"N{d}" for d in (387, 515, 656, 816, 1010)]  # HSC narrow-bands
+        + [f"N{d}" for d in (387, 515, 656, 816, 921, 1010)]  # HSC narrow-bands
     )
     """band names supported by this packer.
 


### PR DESCRIPTION
This is really a patch for DM-29944, which was really only needed to add this one filter and somehow managed to add all of the narrow-band filters but  this one.