### PR TITLE
DM-33157: Fix doxygen errors in pipe_tasks

### DIFF
--- a/ups/skymap.cfg
+++ b/ups/skymap.cfg
@@ -4,7 +4,6 @@ import lsst.sconsUtils
 
 dependencies = {
     "required": ["afw", "daf_base"],
-    "optional": ["daf_butler"],
 }
 
 config = lsst.sconsUtils.Configuration(


### PR DESCRIPTION
This PR prevents a "missing tag file" error when building docs in `skymap` or downstream packages like `pipe_tasks`.