### PR TITLE
DM-41724: Remove (ra, dec) from tract record in butler registration.

### DIFF
--- a/python/lsst/skymap/baseSkyMap.py
+++ b/python/lsst/skymap/baseSkyMap.py
@@ -31,7 +31,7 @@ import numpy as np
 
 import lsst.geom as geom
 import lsst.pex.config as pexConfig
-from lsst.geom import SpherePoint, Angle, arcseconds, degrees
+from lsst.geom import Angle, arcseconds, degrees
 from . import detail
 from .tractBuilder import tractBuilderRegistry
 
@@ -449,14 +449,11 @@ class BaseSkyMap:
                 for tractInfo in self:
                     tractId = tractInfo.getId()
                     tractRegion = tractInfo.getOuterSkyPolygon()
-                    centroid = SpherePoint(tractRegion.getCentroid())
                     tractWcs = tractInfo.getWcs()
                     tractRecord = dict(
                         skymap=name,
                         tract=tractId,
                         region=tractRegion,
-                        ra=centroid.getRa().asDegrees(),
-                        dec=centroid.getDec().asDegrees(),
                     )
                     butler.registry.insertDimensionData("tract", tractRecord)
 


### PR DESCRIPTION
As far as I can tell, tract dimension records have never had (ra, dec) fields, and we didn't notice because DimensionRecord ignores kwargs it doesn't recognize (until now).