### PR TITLE
DM-44796: Deprecate getInnerSkyPolygon() and replace with getInnerSkyRegion() (RFC-1025)

### DIFF
--- a/python/lsst/skymap/healpixSkyMap.py
+++ b/python/lsst/skymap/healpixSkyMap.py
@@ -22,6 +22,7 @@
 
 __all__ = ['HealpixSkyMapConfig', 'HealpixSkyMap']
 
+from deprecated.sphinx import deprecated
 import struct
 import numpy
 
@@ -33,6 +34,9 @@ from .cachingSkyMap import CachingSkyMap
 from .tractInfo import TractInfo
 
 
+# TODO: Remove with DM-44799
+@deprecated("angToCoord has been deprecated and will be removed after v28.",
+            category=FutureWarning, version=28)
 def angToCoord(thetaphi):
     """Convert hpgeom ang to an lsst.geom.SpherePoint
 
@@ -43,6 +47,9 @@ def angToCoord(thetaphi):
     return geom.SpherePoint(float(thetaphi[1]), float(thetaphi[0] - 0.5*numpy.pi), geom.radians)
 
 
+# TODO: Remove with DM-44799
+@deprecated("coordToAnge has been deprecated and will be removed after v28.",
+            category=FutureWarning, version=28)
 def coordToAng(coord):
     """Convert an lsst.geom.SpherePoint to a hpgeom ang (theta, phi)
 
@@ -51,6 +58,9 @@ def coordToAng(coord):
     return (coord.getLatitude().asRadians() + 0.5*numpy.pi, coord.getLongitude().asRadians())
 
 
+# TODO: Remove with DM-44799
+@deprecated("HealpixTractInfo has been deprecated and will be removed after v28.",
+            category=FutureWarning, version=28)
 class HealpixTractInfo(TractInfo):
     """Tract for the HealpixSkyMap"""
 
@@ -62,6 +72,9 @@ class HealpixTractInfo(TractInfo):
                                                vertexList, tractOverlap, wcs)
 
 
+# TODO: Remove with DM-44799
+@deprecated("HealpixSkyMapConfig has been deprecated and will be removed after v28.",
+            category=FutureWarning, version=28)
 class HealpixSkyMapConfig(CachingSkyMap.ConfigClass):
     """Configuration for the HealpixSkyMap"""
     log2NSide = Field(dtype=int, default=0, doc="Number of sides, expressed in powers of 2")
@@ -71,6 +84,9 @@ class HealpixSkyMapConfig(CachingSkyMap.ConfigClass):
         self.rotation = 45  # HEALPixels are oriented at 45 degrees
 
 
+# TODO: Remove with DM-44799
+@deprecated("HealpixSkyMap has been deprecated and will be removed after v28.",
+            category=FutureWarning, version=28)
 class HealpixSkyMap(CachingSkyMap):
     """HEALPix-based sky map pixelization.
 

--- a/tests/test_healpixSkyMap.py
+++ b/tests/test_healpixSkyMap.py
@@ -8,10 +8,12 @@ import hpgeom
 from lsst.skymap.healpixSkyMap import HealpixSkyMap
 
 
+# TODO: Remove with DM-44799
 class HealpixTestCase(skyMapTestCase.SkyMapTestCase):
 
     def setUp(self):
-        config = HealpixSkyMap.ConfigClass()
+        with self.assertWarns(FutureWarning):
+            config = HealpixSkyMap.ConfigClass()
         nside = 2**config.log2NSide
         self.setAttributes(
             SkyMapClass=HealpixSkyMap,
@@ -21,6 +23,60 @@ class HealpixTestCase(skyMapTestCase.SkyMapTestCase):
             numNeighbors=1,
             neighborAngularSeparation=hpgeom.max_pixel_radius(nside) * geom.degrees,
         )
+
+    def getSkyMap(self, config=None):
+        with self.assertWarns(FutureWarning):
+            skymap = super().getSkyMap(config=config)
+        return skymap
+
+    def getConfig(self):
+        with self.assertWarns(FutureWarning):
+            config = super().getConfig()
+        return config
+
+    # def testRegistry(self):
+    #     with self.assertWarns(FutureWarning):
+    #         super().testRegistry()
+
+    def testBasicAttributes(self):
+        with self.assertWarns(FutureWarning):
+            super().testBasicAttributes()
+
+    def testPickle(self):
+        with self.assertWarns(FutureWarning):
+            super().testPickle()
+
+    def testTractSeparation(self):
+        with self.assertWarns(FutureWarning):
+            super().testTractSeparation()
+
+    def testFindPatchList(self):
+        with self.assertWarns(FutureWarning):
+            super().testFindPatchList()
+
+    def testFindTractPatchList(self):
+        with self.assertWarns(FutureWarning):
+            super().testFindTractPatchList()
+
+    def testTractContains(self):
+        with self.assertWarns(FutureWarning):
+            super().testTractContains()
+
+    def testTractInfoGetPolygon(self):
+        with self.assertWarns(FutureWarning):
+            super().testTractInfoGetPolygon()
+
+    def testPatchInfoGetPolygon(self):
+        with self.assertWarns(FutureWarning):
+            super().testPatchInfoGetPolygon()
+
+    def testDm14809(self):
+        with self.assertWarns(FutureWarning):
+            super().testDm14809()
+
+    def testNumbering(self):
+        with self.assertWarns(FutureWarning):
+            super().testNumbering()
 
     def testSha1Compare(self):
         """Test that HealpixSkyMap's extra state is included in its hash."""

--- a/tests/test_healpixSkyMap.py
+++ b/tests/test_healpixSkyMap.py
@@ -70,6 +70,10 @@ class HealpixTestCase(skyMapTestCase.SkyMapTestCase):
         with self.assertWarns(FutureWarning):
             super().testPatchInfoGetPolygon()
 
+    def testTractInfoGetRegion(self):
+        with self.assertWarns(FutureWarning):
+            super().testTractInfoGetRegion()
+
     def testDm14809(self):
         with self.assertWarns(FutureWarning):
             super().testDm14809()

--- a/tests/test_ringsSkyMap.py
+++ b/tests/test_ringsSkyMap.py
@@ -57,6 +57,23 @@ class RingsTestCase(skyMapTestCase.SkyMapTestCase):
             for coord in vertices:
                 self.assertIn(tract.getId(), [tt.getId() for tt in skymap.findAllTracts(coord)])
 
+    def testInnerSkyRegion(self):
+        """Test that the inner_sky_region covers the inner sky region."""
+        skymap = self.getSkyMap()
+        for tract in skymap:
+            innerSkyRegion = tract.inner_sky_region
+            bbox = tract.bbox
+            wcs = tract.wcs
+            x = np.linspace(bbox.getMinX(), bbox.getMaxX(), 100)
+            y = np.linspace(bbox.getMinY(), bbox.getMaxY(), 100)
+            xx, yy = np.meshgrid(x, y)
+
+            ra, dec = wcs.pixelToSkyArray(xx.ravel(), yy.ravel())
+            np.testing.assert_array_equal(
+                innerSkyRegion.contains(ra, dec),
+                skymap.findTractIdArray(ra, dec) == tract.getId(),
+            )
+
 
 class NonzeroRaStartRingsTestCase(RingsTestCase):
     """Test that setting raStart != 0 works"""

--- a/tests/test_tractInfo.py
+++ b/tests/test_tractInfo.py
@@ -33,7 +33,10 @@ class TractInfoTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(tractInfo.patch_inner_dimensions, tractInfo.getPatchInnerDimensions())
         self.assertEqual(tractInfo.tract_overlap, tractInfo.getTractOverlap())
         self.assertEqual(tractInfo.vertex_list, tractInfo.getVertexList())
-        self.assertEqual(tractInfo.inner_sky_polygon, tractInfo.getInnerSkyPolygon())
+        # TODO: Remove with DM-44799
+        with self.assertWarns(FutureWarning):
+            self.assertEqual(tractInfo.inner_sky_polygon, tractInfo.getInnerSkyPolygon())
+        self.assertEqual(tractInfo.inner_sky_region, tractInfo.getInnerSkyRegion())
         self.assertEqual(tractInfo.outer_sky_polygon, tractInfo.getOuterSkyPolygon())
         self.assertEqual(tractInfo.wcs, tractInfo.getWcs())
 


### PR DESCRIPTION
This PR also deprecates the healpix skymap which can't be easily represented with a simple inner region.